### PR TITLE
Make GitHub detedt blocks.bin as Forth

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+blocks.bin linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect the `blocks.bin` files as Forth.

Thanks!
